### PR TITLE
GroupSettings下的remove_friend_from_group修正

### DIFF
--- a/pywechat/WechatAuto.py
+++ b/pywechat/WechatAuto.py
@@ -3779,7 +3779,7 @@ class GroupSettings():
             delete.click_input()
             delete_member_window=main_window.child_window(**Main_window.DeleteMemberWindow)
             for member in friends:
-                search=delete_member_window.child_window(*Edits.SearchEdit)
+                search=delete_member_window.child_window(**Edits.SearchEdit)
                 search.click_input()
                 Systemsettings.copy_text_to_windowsclipboard(member)
                 pyautogui.hotkey('ctrl','v')


### PR DESCRIPTION
remove_friend_from_group内child_window定位元素解包kwargs时少了一个*会导致报错