### PR TITLE
feat: 偶发微信界面上的子页面展示的时候不在最上层，被遮挡住了，导致后面的功能异常，此次提交为防护这种情况

### DIFF
--- a/pyweixin/WeChatTools.py
+++ b/pyweixin/WeChatTools.py
@@ -334,6 +334,10 @@ class Tools():
             win32gui.MoveWindow(handle, new_left, new_top, window_width, window_height, True)
             win32gui.SetWindowPos(handle,win32con.HWND_TOPMOST, 
                 0, 0, 0, 0,win32con.SWP_NOMOVE|win32con.SWP_NOSIZE)
+        try:
+            window.set_focus() 
+        except:
+            pass
         return window
 
     @staticmethod


### PR DESCRIPTION
偶发微信界面上的子页面展示的时候不在最上层，被遮挡住了，导致后面的功能异常，此次提交为防护这种情况