### PR TITLE
fix(Mcp): 修复 MCP 服务器打包与入口点问题

### DIFF
--- a/Mcp/pyproject.toml
+++ b/Mcp/pyproject.toml
@@ -13,7 +13,7 @@ dependencies=[
     "psutil>=5.9.5",
     "pyautogui>=0.9.54",
     "pycaw>=20240210",
-    "pywin32>=308"，
+    "pywin32>=308",
     "pywin32-ctypes>=0.2.2",
     "pywinauto>=0.6.8",
     "pillow>=10.4.0",
@@ -25,7 +25,7 @@ dependencies=[
 ]
 
 [project.scripts]
-pyweixin-rpa="mcp_server.server:main"
+pyweixin-rpa="pyweixin_rpa.mcp_server.server:main"
 
 [build-system]
 requires=["setuptools>=61.0"]

--- a/Mcp/pyweixin_rpa/mcp_server/server.py
+++ b/Mcp/pyweixin_rpa/mcp_server/server.py
@@ -1,9 +1,12 @@
 from fastmcp import FastMCP
-from mcp_server.tools.messaging import mcp as messaging_mcp
+from .tools.messaging import mcp as messaging_mcp
 mcp=FastMCP("pyweixin_rpa")
 
 # 挂载子模块
 mcp.mount(messaging_mcp)
 
-if __name__ == "__main__":
+def main():
     mcp.run()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 修复 MCP 服务器无法安装/运行的 3 个打包问题

在本地部署 `Mcp/` 目录的 MCP 服务器时（Windows 11 + Python 3.12 + 微信 4.1.12.55），发现以下问题导致 `pip install -e .` 后 `pyweixin-rpa` 命令完全无法运行：

### 1. `Mcp/pyproject.toml` — 中文全角逗号导致安装失败

```diff
-    "pywin32>=308"，
+    "pywin32>=308",
```

`dependencies` 列表中混入了中文全角逗号 `，`，pip 解析依赖时直接报错。

### 2. `Mcp/pyproject.toml` — entry point 指向不存在的模块

```diff
-pyweixin-rpa="mcp_server.server:main"
+pyweixin-rpa="pyweixin_rpa.mcp_server.server:main"
```

包结构是 `pyweixin_rpa/mcp_server/`，`mcp_server` 不是顶层包，原 entry point 永远无法解析。

### 3. `Mcp/pyweixin_rpa/mcp_server/server.py` — 导入方式与缺失的 main()

```diff
-from mcp_server.tools.messaging import mcp as messaging_mcp
+from .tools.messaging import mcp as messaging_mcp
 ...
+def main():
+    mcp.run()
+
 if __name__ == "__main__":
-    mcp.run()
+    main()
```

- 顶层导入 `mcp_server.tools.messaging` 在包安装后无法解析，改为相对导入
- entry point 引用的 `main` 函数原本不存在（只有 `if __name__ == "__main__"` 块），补上

### 验证

- `pip install -e .`（`src/` 与 `Mcp/`）均成功
- `pyweixin-rpa` 命令可正常启动，MCP 握手（initialize + tools/list）通过
- 正确暴露 `wechat_send_messages`、`wechat_send_audios` 两个工具

---

> **说明**：本 PR 由 AI 模型 **Qwen3.8-27B**（运行于 pi coding agent 框架）在为用户部署本项目时提交，人类用户仅负责审核。所有修改均经过本地实际运行验证，未改动任何业务逻辑。
